### PR TITLE
Docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quartz/js-utils",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quartz/js-utils",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quartz/js-utils",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A collection of reusable JavaScript utilities for Quartz products.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:eslint": "eslint --ignore-path .gitignore src",
     "test:unit": "jest",
     "build": "tsc",
-    "prepublish": "npm run build"
+    "publish": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quartz/js-utils",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A collection of reusable JavaScript utilities for Quartz products.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quartz/js-utils",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "A collection of reusable JavaScript utilities for Quartz products.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,7 +12,7 @@
     "test:eslint": "eslint --ignore-path .gitignore src",
     "test:unit": "jest",
     "build": "tsc",
-    "publish": "npm run build"
+    "prepublishOnly": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,36 @@
-# JavaScript utilities
+# Quartz JavaScript utilities
 
-A collection of reusable JavaScript utilities for Quartz products.
+[![npm version](https://badge.fury.io/js/%40quartz%2Fjs-utils.svg)](https://badge.fury.io/js/%40quartz%2Fjs-utils)
+
+A collection of reusable JavaScript utilities for Quartz products, with optional TypeScript support.
+
+All functions are written in TypeScript and transpiled into ES2017 JavaScript (with type definitions).
+
+## Installation
+
+`npm i @quartz/js-utils`
+
+## Usage
+
+Import functions from the js-utils package, e.g.
+
+`import { arrayFromRange, resizeWPImage } from '@quartz/js-utils'`
+
+TypeScript hints are available if the file into which the functions are imported is a `.ts` or `.tsx` file.
+
+## Contributing
+
+Functions must be written in TypeScript whenever possible.
+
+Export one function per file with a test suite (`.test.js`).
+
+### Before opening a pull request
+
+- Export any new functions to `src/index.ts`
+- Add a test suite for any new functions
+- Ensure tests pass (`npm t`)
+- Increment the package.json version using `npm version`
+
+## Deploying
+
+Use `npm publish` to publish the package to npm. TypeScript will be built on publish (via `npm run build`).

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Quartz JavaScript utilities
 
-[![npm version](https://badge.fury.io/js/%40quartz%2Fjs-utils.svg)](https://badge.fury.io/js/%40quartz%2Fjs-utils)
+[![npm version](https://badge.fury.io/js/%40quartz%2Fjs-utils.svg)](https://www.npmjs.com/package/@quartz/js-utils)
 
 A collection of reusable JavaScript utilities for Quartz products, with optional TypeScript support.
 

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ Export one function per file with a test suite (`.test.js`).
 - Export any new functions to `src/index.ts`
 - Add a test suite for any new functions
 - Ensure tests pass (`npm t`)
-- Increment the package.json version using `npm version`
+- Increment the `package.json` version using `npm version`
 
 ## Deploying
 


### PR DESCRIPTION
Adds some more info for readme and switch the `prepublish` script for `prepublishOnly` so it doesn't run after `npm install` (see https://docs.npmjs.com/misc/scripts)