### PR TITLE
Build to CommonJS modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quartz/js-utils",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quartz/js-utils",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quartz/js-utils",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quartz/js-utils",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A collection of reusable JavaScript utilities for Quartz products.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quartz/js-utils",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A collection of reusable JavaScript utilities for Quartz products.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quartz/js-utils",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A collection of reusable JavaScript utilities for Quartz products.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"declaration": true,
-		"module": "es6",
+		"module": "commonjs",
 		"allowSyntheticDefaultImports": true,
 		"strictNullChecks": true,
 		"target": "es2017",


### PR DESCRIPTION
Use CommonJS for modules so that (older) Node versions can support this package without Babel in between