### PR TITLE
Improve ColorScheme helper functions

### DIFF
--- a/src/hexToRGB.ts
+++ b/src/hexToRGB.ts
@@ -1,10 +1,7 @@
 /**
  * Convert a hex color like #336699 to an array of RGB values.
- *
- * @param  {String} hexColor 3- or 6-character hex color.
- * @return {Array}
  */
-export default function hexToRGB( hexColor: string ) {
+export default function hexToRGB( hexColor: string ): [number, number, number] {
 	// Remove # from arg.
 	let hex = hexColor.slice( 1 );
 

--- a/src/minifyCss.ts
+++ b/src/minifyCss.ts
@@ -6,5 +6,5 @@
  * @return {String}
  */
 export default function minifyCss ( css: string ) {
-	return css.replace( /\s*([{}\(\);:,])\s*/g, '$1' );
+	return css.replace( /\s*([{}\(\);:,])\s*/g, '$1' ).trim();
 }


### PR DESCRIPTION
Typescript will parse doc blocks if no explicit type hints are provided. In the case of HexRgb, it was using a generic Array return type, when we actually can be specific that it's an Array of three numbers.

Improving minify to trim the string.