### PR TITLE
ez fix for handling bad url's

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quartz/js-utils",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/resizeWPImage.ts
+++ b/src/resizeWPImage.ts
@@ -8,22 +8,26 @@
  * @param  {int}    quality
  * @return {string}
  */
-export default function resizeWPImage ( url: string, width?: number, height?: number, crop = false, quality = 75 ) {
-	const { origin, pathname } = new URL( url );
+export default function resizeWPImage ( url?: string, width?: number, height?: number, crop = false, quality = 75 ) {
+	if (!url) {
+		return '';
+	} else {
+		const { origin, pathname } = new URL( url );
 
-	let resizedUrl = `${origin}${pathname}?quality=${quality}&strip=all`;
-
-	if ( width ) {
-		resizedUrl += `&w=${width}`;
+		let resizedUrl = `${origin}${pathname}?quality=${quality}&strip=all`;
+	
+		if ( width ) {
+			resizedUrl += `&w=${width}`;
+		}
+	
+		if ( height ) {
+			resizedUrl += `&h=${height}`;
+		}
+	
+		if ( crop ) {
+			resizedUrl += '&crop=1';
+		}
+	
+		return resizedUrl;
 	}
-
-	if ( height ) {
-		resizedUrl += `&h=${height}`;
-	}
-
-	if ( crop ) {
-		resizedUrl += '&crop=1';
-	}
-
-	return resizedUrl;
 }


### PR DESCRIPTION
Easiest way to ensure bad urls being passed to `resizeWpImage` don't throw 500s

Edit: accidentally put the wrong linear issue number. Should be qz-218: https://linear.app/qz/issue/QZ-218/discover-page-is-broken 